### PR TITLE
Remove example mentioning str_eq lang item

### DIFF
--- a/src/attributes.md
+++ b/src/attributes.md
@@ -408,20 +408,7 @@ pub mod m3 {
 Some primitive Rust operations are defined in Rust code, rather than being
 implemented directly in C or assembly language. The definitions of these
 operations have to be easy for the compiler to find. The `lang` attribute
-makes it possible to declare these operations. For example, the `str` module
-in the Rust standard library defines the string equality function:
-
-```rust,ignore
-#[lang = "str_eq"]
-pub fn eq_slice(a: &str, b: &str) -> bool {
-    // details elided
-}
-```
-
-The name `str_eq` has a special meaning to the Rust compiler, and the presence
-of this definition means that it will use this definition when generating calls
-to the string equality function.
-
+makes it possible to declare these operations.
 The set of language items is currently considered unstable. A complete
 list of the built-in language items will be added in the future.
 


### PR DESCRIPTION
It's a useless lang item [which we should remove](https://github.com/rust-lang/rust/pull/44658) so not a good example. There is not drop in replacement because I think it was the only lang item that was just an fn.